### PR TITLE
Temporary fix for homepage crash

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "avail_wallet"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "app_dirs2",
  "avail-common",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail_wallet"
-version = "0.0.7"
+version = "0.0.8"
 description = "Frictionless control of your money and data."
 authors = ["Avail"]
 license = "Apache-2.0"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -32,7 +32,7 @@
         </dict>
     </array>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.7</string>
+	<string>0.0.8</string>
 	<key>CFBundleVersion</key>
 	<string>20240222.152850</string>
 	<key>CSResourcesFileMapped</key>

--- a/src/views-desktop/home-desktop.tsx
+++ b/src/views-desktop/home-desktop.tsx
@@ -415,7 +415,7 @@ function Home() {
 				}}>
 					{scanInProgress
 						&& <mui.Box sx={{ width: '100%', bgcolor: '#00FFAA', height: '30px' }}>
-							<SmallText400 sx={{ color: '#111111' }}> {t('home.scan.progress')} {scanProgressPercent.toString()}%{t('home.scan.complete')}</SmallText400>
+							<SmallText400 sx={{ color: '#111111' }}> {t('home.scan.progress')} {scanProgressPercent?.toString()}%{t('home.scan.complete')}</SmallText400>
 						</mui.Box>
 					}
 					{scanInProgress


### PR DESCRIPTION
### Logs
Home page errors once the scan is complete. The scan percentage value returned from the client backend might have caused this issue.
NOTE - The network is also choppy so that is a factor too
### Screenshot
![screenshot_2024-03-19_at_11 49 20___pm_720](https://github.com/AvailX/avail-wallet/assets/106152383/7f67f175-af5a-4548-9e85-2088a4148db3)
### Fix 
Just handling it when the value might be undefined or null, a temp fix for now
