### PR TITLE
Adds API Client Switching as Obscura Parsing and `get_blocks` fails

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,13 +66,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -421,7 +422,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avail-common"
 version = "0.6.0"
-source = "git+https://github.com/availx/avail-lib?rev=934a8d0#934a8d0057ae00561179683f6a1b82cee048fcca"
+source = "git+https://github.com/availx/avail-lib?rev=761411b#761411b87caee6d77535db136467a4b8e69ce0fa"
 dependencies = [
  "aes-gcm",
  "app_dirs2",
@@ -2195,7 +2196,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.1.0",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2210,9 +2211,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2224,7 +2225,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2517,12 +2518,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.5",
  "rayon",
  "serde",
 ]
@@ -2865,7 +2866,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4548,11 +4549,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "itoa 1.0.6",
  "ryu",
  "serde",
@@ -4739,14 +4740,14 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anstyle",
  "anyhow",
  "clap",
  "colored",
  "dotenvy",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "num-format",
  "once_cell",
  "parking_lot",
@@ -4768,16 +4769,16 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
  "blake2",
  "cfg-if",
  "fxhash",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.5",
  "hex",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "itertools",
  "num-traits",
  "parking_lot",
@@ -4798,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4812,7 +4813,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -4823,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4833,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4843,9 +4844,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "itertools",
  "nom",
  "num-traits",
@@ -4861,12 +4862,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4877,7 +4878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4892,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4907,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4920,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4929,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4939,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4951,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4963,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4974,7 +4975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4986,7 +4987,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4999,7 +5000,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5010,7 +5011,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -5023,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -5034,10 +5035,10 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anyhow",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "itertools",
  "lazy_static",
  "once_cell",
@@ -5057,7 +5058,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5075,12 +5076,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "enum-iterator",
  "enum_index",
  "enum_index_derive",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "num-derive 0.4.0",
  "num-traits",
  "once_cell",
@@ -5097,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5112,7 +5113,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5123,7 +5124,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5131,7 +5132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5141,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5152,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5163,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5174,7 +5175,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5185,7 +5186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -5199,7 +5200,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5216,11 +5217,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -5240,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5252,9 +5253,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5271,9 +5272,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5283,7 +5284,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5296,9 +5297,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5309,9 +5310,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5321,7 +5322,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5332,9 +5333,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "rayon",
  "serde_json",
  "snarkvm-console",
@@ -5347,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5360,7 +5361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5369,12 +5370,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "lru",
  "once_cell",
  "parking_lot",
@@ -5389,12 +5390,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
  "colored",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "lru",
  "parking_lot",
  "rand 0.8.5",
@@ -5410,7 +5411,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "async-trait",
  "reqwest 0.11.20",
@@ -5423,12 +5424,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
  "bincode",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "parking_lot",
  "rayon",
  "serde",
@@ -5446,7 +5447,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5455,7 +5456,7 @@ dependencies = [
  "colored",
  "curl",
  "hex",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "itertools",
  "lazy_static",
  "parking_lot",
@@ -5471,11 +5472,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "itertools",
  "lru",
  "parking_lot",
@@ -5501,11 +5502,11 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "colored",
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "once_cell",
  "parking_lot",
  "rand 0.8.5",
@@ -5524,9 +5525,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5538,7 +5539,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bincode",
  "once_cell",
@@ -5551,7 +5552,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5572,7 +5573,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
+source = "git+https://github.com/AleoNet/snarkVM?rev=d170a9f#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",
@@ -6486,7 +6487,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7652,6 +7653,26 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "avail_wallet"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "app_dirs2",
  "avail-common",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avail-common"
 version = "0.6.0"
-source = "git+https://github.com/availx/avail-lib?rev=761411b#761411b87caee6d77535db136467a4b8e69ce0fa"
+source = "git+https://github.com/availx/avail-lib?rev=9093fad#9093fadbfbbc95cebdb7001e38110d9d0b325773"
 dependencies = [
  "aes-gcm",
  "app_dirs2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "avail-common"
 version = "0.6.0"
-source = "git+https://github.com/availx/avail-lib?rev=130c38b611648422a3ce07b1ed4b7f266f049255#130c38b611648422a3ce07b1ed4b7f266f049255"
+source = "git+https://github.com/availx/avail-lib?rev=934a8d0#934a8d0057ae00561179683f6a1b82cee048fcca"
 dependencies = [
  "aes-gcm",
  "app_dirs2",
@@ -1500,6 +1500,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4719,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4748,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4778,7 +4798,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4792,7 +4812,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -4803,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4813,7 +4833,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4823,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "itertools",
@@ -4841,12 +4861,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4857,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4872,7 +4892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4887,7 +4907,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4900,7 +4920,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4909,7 +4929,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4919,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4931,7 +4951,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4943,7 +4963,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4954,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4966,7 +4986,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4979,7 +4999,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4990,7 +5010,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -5003,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -5014,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -5037,7 +5057,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5055,8 +5075,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
+ "enum-iterator",
  "enum_index",
  "enum_index_derive",
  "indexmap 2.0.0",
@@ -5076,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5091,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5102,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5110,7 +5131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5120,7 +5141,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5131,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5142,7 +5163,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5153,7 +5174,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5164,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -5178,7 +5199,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5195,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5219,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -5231,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -5250,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -5262,7 +5283,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5275,7 +5296,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -5288,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -5300,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5311,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "rayon",
@@ -5326,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5339,7 +5360,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5348,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5368,22 +5389,28 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
+ "aleo-std",
  "anyhow",
  "colored",
  "indexmap 2.0.0",
+ "lru",
+ "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
+ "snarkvm-circuit",
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
+ "snarkvm-synthesizer-process",
+ "snarkvm-synthesizer-program",
 ]
 
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "async-trait",
  "reqwest 0.11.20",
@@ -5396,7 +5423,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -5419,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5444,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5454,6 +5481,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rayon",
+ "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -5473,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "colored",
@@ -5496,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "indexmap 2.0.0",
  "paste",
@@ -5510,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "bincode",
  "once_cell",
@@ -5523,7 +5551,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5544,7 +5572,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM?branch=testnet-beta#140ff26f87697c2e9d18212cce2cc831fc4b146a"
+source = "git+https://github.com/AleoNet/snarkVM?branch=mainnet#d170a9f7c5ef980f9392301dc899dee355599ca6"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "=2.0.0-beta.13", features = [] }
 
 
 [dependencies]
-avail-common = { git = "https://github.com/availx/avail-lib", rev = "761411b", features = [
+avail-common = { git = "https://github.com/availx/avail-lib", rev = "9093fad", features = [
     "snarkvm",
 ] }
 app_dirs = { package = "app_dirs2", version = "2.5" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri-build = { version = "=2.0.0-beta.13", features = [] }
 
 [dependencies]
 app_dirs = { package = "app_dirs2", version = "2.5" }
-avail-common = { git = "https://github.com/availx/avail-lib", rev = "130c38b611648422a3ce07b1ed4b7f266f049255", features = [
+avail-common = { git = "https://github.com/availx/avail-lib", rev = "934a8d0", features = [
     "snarkvm",
 ] }
 bs58 = "0.5.0"
@@ -44,7 +44,7 @@ rusqlite = { version = "0.29.0", features = ["bundled", "chrono"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snarkvm = { version = "0.16.19", features = [
-], git = "https://github.com/AleoNet/snarkVM", branch = "testnet-beta" }
+], git = "https://github.com/AleoNet/snarkVM", branch = "mainnet" }
 ssss = "0.2.0"
 tauri = { version = "2.0.0-beta.17", features = [] }
 tauri-plugin-deep-link = "=2.0.0-beta.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,10 +21,10 @@ tauri-build = { version = "=2.0.0-beta.13", features = [] }
 
 
 [dependencies]
-app_dirs = { package = "app_dirs2", version = "2.5" }
-avail-common = { git = "https://github.com/availx/avail-lib", rev = "934a8d0", features = [
+avail-common = { git = "https://github.com/availx/avail-lib", rev = "761411b", features = [
     "snarkvm",
 ] }
+app_dirs = { package = "app_dirs2", version = "2.5" }
 bs58 = "0.5.0"
 chrono = "0.4.26"
 dirs = "5.0.1"
@@ -42,9 +42,9 @@ rand = "0.8.5"
 rayon = "1.7.0"
 rusqlite = { version = "0.29.0", features = ["bundled", "chrono"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-snarkvm = { version = "0.16.19", features = [
-], git = "https://github.com/AleoNet/snarkVM", branch = "mainnet" }
+serde_json = "1.0.120"
+snarkvm = { features = [
+], git = "https://github.com/AleoNet/snarkVM", rev = "d170a9f" }
 ssss = "0.2.0"
 tauri = { version = "2.0.0-beta.17", features = [] }
 tauri-plugin-deep-link = "=2.0.0-beta.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avail_wallet"
-version = "0.4.1"
+version = "0.4.2"
 description = "Avail Wallet | Make it yours."
 authors = ["Avail"]
 license = "Apache-2.0"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -32,7 +32,7 @@
         </dict>
     </array>
   <key>CFBundleShortVersionString</key>
-	<string>0.4.1</string>
+	<string>0.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>20240222.152850</string>
 	<key>CSResourcesFileMapped</key>

--- a/src-tauri/src/api/aleo_client.rs
+++ b/src-tauri/src/api/aleo_client.rs
@@ -57,6 +57,11 @@ pub fn setup_obscura_client<N: Network>() -> AvailResult<AleoAPIClient<N>> {
     Ok(api_client)
 }
 
+pub fn setup_aleo_client<N: Network>() -> AvailResult<AleoAPIClient<N>> {
+    let aleo_client = AleoAPIClient::<N>::new("https://api.explorer.aleo.org/v1", "testnet")?;
+    Ok(aleo_client)
+}
+
 pub fn network_status<N: Network>() -> AvailResult<Status> {
     let obscura_client = setup_obscura_client::<N>()?;
     let aleo_client = AleoAPIClient::<N>::new("https://api.explorer.aleo.org/v1", "testnet")?;

--- a/src-tauri/src/services/record_handling/records.rs
+++ b/src-tauri/src/services/record_handling/records.rs
@@ -3,7 +3,7 @@ use futures::lock::MutexGuard;
 use snarkvm::{
     circuit::group::add,
     console::program::Itertools,
-    ledger::Block,
+    ledger::block::*,
     prelude::{ConfirmedTransaction, Network, Plaintext, Record},
 };
 use std::ops::Sub;
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use crate::{
     api::{
-        aleo_client::{setup_client, setup_local_client},
+        aleo_client::{setup_aleo_client, setup_client, setup_local_client},
         backup_recovery::update_sync_height,
     },
     helpers::utils::get_timestamp_from_i64,
@@ -63,14 +63,35 @@ pub fn get_records<N: Network>(
     let view_key = VIEWSESSION.get_instance::<N>()?;
     let address = view_key.to_address();
 
-    let api_client = setup_client::<N>()?;
+    let mut api_client = setup_client::<N>()?;
 
     let step_size = 49;
 
     let amount_to_scan = height.sub(last_sync);
     let latest_height = height;
+    println!("BEFORE GET BLOCK");
 
-    let last_sync_block = api_client.get_block(last_sync)?;
+    let (last_sync_block, api_client) = match api_client.get_block(last_sync) {
+        Ok(block) => (block, api_client.clone()),
+        Err(e) => {
+            if e.to_string().contains("Invalid Circuit")
+                || e.to_string().contains("Invalid Data")
+                || e.to_string().contains("Failed to parse block")
+                || e.to_string().contains("JSON")
+            {
+                let api_client_aleo = setup_aleo_client::<N>()?;
+                let block = api_client_aleo.get_block(last_sync)?;
+                (block, api_client_aleo)
+            } else {
+                return Err(AvailError::new(
+                    AvailErrorType::Internal,
+                    e.to_string(),
+                    "Error getting block".to_string(),
+                ));
+            }
+        }
+    };
+    println!("AFTER GET BLOCK \n {:?}", last_sync_block);
     let last_sync_timestamp = get_timestamp_from_i64(last_sync_block.timestamp())?;
 
     // checks if unconfirmed transactions have expired and updates their state to failed

--- a/src-tauri/src/services/record_handling/records.rs
+++ b/src-tauri/src/services/record_handling/records.rs
@@ -69,7 +69,6 @@ pub fn get_records<N: Network>(
 
     let amount_to_scan = height.sub(last_sync);
     let latest_height = height;
-    println!("BEFORE GET BLOCK");
 
     let (last_sync_block, api_client) = match api_client.get_block(last_sync) {
         Ok(block) => (block, api_client.clone()),
@@ -91,7 +90,6 @@ pub fn get_records<N: Network>(
             }
         }
     };
-    println!("AFTER GET BLOCK \n {:?}", last_sync_block);
     let last_sync_timestamp = get_timestamp_from_i64(last_sync_block.timestamp())?;
 
     // checks if unconfirmed transactions have expired and updates their state to failed


### PR DESCRIPTION
So Obscura's `get_block` fails to parse the response JSON to `Block<N>` and `get_blocks` returns a 500 error. 
When Obscura's block fetch fails, this PR implements a temp auto-switching to Aleo's API client.

When and if Obscura gets back to working, this will use Obscura as default, this switch only happens if Obscura fails or throws a JSON error.